### PR TITLE
add dockerfile

### DIFF
--- a/auth-service/.dockerignore
+++ b/auth-service/.dockerignore
@@ -1,0 +1,25 @@
+# Ignore the following:
+.git/
+*.gitignore
+*.md
+*.DS_Store
+*.log
+*.tmp
+.idea/
+.vscode/
+node_modules/
+*.swp
+*.swo
+
+# Ignore local development environments and build artifacts
+auth-service/bin/
+auth-service/pkg/
+auth-service/vendor/
+
+# Ignore Go build artifacts
+auth-service/*.out
+auth-service/*.exe
+auth-service/*.test
+
+# Ignore the .env file (consider keeping it outside of Docker for security reasons)
+.env

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -1,0 +1,33 @@
+# Dockerfile
+
+# Stage 1: Build the app
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /app
+
+# Copy go.mod and go.sum to download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the entire source code of auth-service
+COPY . ./auth-service/
+
+# Set the working directory to where the main.go is located
+WORKDIR /app/auth-service/cmd/myapp
+
+# Build the Go app
+RUN go build -o /auth-service/myapp .
+
+# Stage 2: Create the final lightweight image
+FROM alpine:latest
+
+WORKDIR /root/
+
+# Copy the built binary from the builder stage
+COPY --from=builder /auth-service/myapp .
+
+# Expose the port your app will run on
+EXPOSE 8080
+
+# Command to run the app
+CMD ["./myapp"]

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app/auth-service/cmd/myapp
 RUN go build -o /auth-service/myapp .
 
 # Stage 2: Create the final lightweight image
-FROM alpine:latest
+FROM alpine:3.17
 
 WORKDIR /root/
 

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -15,8 +15,8 @@ COPY . ./auth-service/
 # Set the working directory to where the main.go is located
 WORKDIR /app/auth-service/cmd/myapp
 
-# Build the Go app
-RUN go build -o /auth-service/myapp .
+# Build the Go app with CGO disabled for a fully static binary
+RUN CGO_ENABLED=0 go build -o /auth-service/myapp .
 
 # Stage 2: Create the final lightweight image
 FROM alpine:3.17


### PR DESCRIPTION
## Summary

This PR introduces Docker support for the auth-service. It includes:

- A Dockerfile that:

   - Uses multi-stage builds to keep the final image lightweight.

   - Builds the Go application (myapp) from the source code in /auth-service.

   - Exposes port 8080 and runs the built binary.

- A .dockerignore that:

   - Ignores common development files and directories (e.g., .git/, node_modules/, .vscode/).

   - Ignores Go build artifacts and vendor folders.

    - Ignores .env files for security.

## Summary by Sourcery

Add Docker support for the auth-service by creating a Dockerfile and .dockerignore file

New Features:
- Introduced multi-stage Docker build for the auth-service application

Deployment:
- Created Dockerfile that builds and packages the Go application
- Added .dockerignore to optimize Docker image build